### PR TITLE
Group details screen layout

### DIFF
--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -77,6 +78,7 @@ import io.taptap.uikit.StupidEnglishScaffold
 import io.taptap.uikit.StupidEnglishTopAppBar
 import io.taptap.uikit.complex.WordItemRow
 import io.taptap.uikit.fab.BOTTOM_BAR_MARGIN
+import io.taptap.uikit.group.GroupItemUI
 import io.taptap.uikit.group.getTitle
 import io.taptap.uikit.theme.StupidEnglishTheme
 import io.taptap.uikit.theme.StupidLanguageBackgroundBox
@@ -186,6 +188,7 @@ fun MainList(
 ) {
     LazyColumn(
         state = listState,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
         contentPadding = PaddingValues(
             top = WindowInsets.navigationBars.getTop(LocalDensity.current).dp,
             bottom = WindowInsets.navigationBars.getBottom(LocalDensity.current).dp + 12.dp + BOTTOM_BAR_MARGIN
@@ -226,12 +229,16 @@ fun MainList(
                             ButtonId.learn -> onEventSent(Event.ToAddSentence)
                             ButtonId.addWord -> onEventSent(Event.OnAddWordClick)
                         }
-                    }
+                    },
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxWidth()
                 )
 
                 is GroupDetailsDynamicTitleUI -> AverageTitle(
                     text = item.currentGroup.getTitle(),
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp)
+                    modifier = Modifier
+                        .padding(start = 16.dp, end = 16.dp, top = 8.dp)
                 )
 
                 is GroupDetailsEmptyUI -> EmptyListContent(
@@ -243,7 +250,9 @@ fun MainList(
                 is GroupDetailsWordItemUI -> WordItemRow(
                     word = item.word,
                     description = item.description,
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .animateItemPlacement(),
                     dismissState = dismissState,
                     onClicked = {}
                 )

--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
@@ -3,29 +3,48 @@ package io.taptap.stupidenglish.features.groupdetails.ui
 import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Card
 import androidx.compose.material.DismissDirection
 import androidx.compose.material.DismissValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarResult
+import androidx.compose.material.Text
 import androidx.compose.material.rememberDismissState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.taptap.stupidenglish.R
 import io.taptap.stupidenglish.base.LAUNCH_LISTEN_FOR_EFFECTS
@@ -51,6 +70,7 @@ import io.taptap.uikit.theme.StupidLanguageBackgroundBox
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
+import kotlin.math.absoluteValue
 
 
 @ExperimentalFoundationApi
@@ -243,6 +263,103 @@ fun MainListPreview() {
             ),
             listState = rememberLazyListState(),
             onEventSent = {},
+        )
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun WordPager(
+    words: List<Pair<String, String>>,
+    modifier: Modifier = Modifier
+) {
+    val pagerState = rememberPagerState {
+        words.size
+    }
+
+    val singlePageWithNeighbourEdges = object : PageSize {
+        private val edgesWidth = 24.dp
+
+        override fun Density.calculateMainAxisPageSize(availableSpace: Int, pageSpacing: Int): Int =
+            availableSpace - edgesWidth.roundToPx()
+    }
+
+    Column {
+        val pagerHeight = 220.dp
+        val pageHeight = 200.dp
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = modifier
+                .height(pagerHeight),
+            pageSize = singlePageWithNeighbourEdges,
+            pageSpacing = 8.dp,
+            contentPadding = PaddingValues(
+                start = 30.dp, //FIXME MAGIC NUMBERS. Подбирал. Почему именно такие?
+                end = 8.dp
+            ),
+        ) { page ->
+            val pageHeightDelta = calculatePageHeightDelta(pagerState, page)
+
+            Card(
+                Modifier
+                    .fillMaxWidth()
+                    .height(pageHeight + pageHeightDelta)
+            ) {
+                Box {
+                    Text(
+                        text = words[page].first,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                    )
+                }
+            }
+        }
+
+        Row(
+            Modifier
+                .height(50.dp)
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            repeat(words.size) { iteration ->
+                val color =
+                    if (pagerState.currentPage == iteration) Color.DarkGray else Color.LightGray
+                Box(
+                    modifier = Modifier
+                        .padding(2.dp)
+                        .clip(CircleShape)
+                        .background(color)
+                        .size(8.dp)
+                )
+            }
+        }
+    }
+}
+
+@ExperimentalFoundationApi
+private fun calculatePageHeightDelta(
+    pagerState: PagerState,
+    page: Int
+): Dp = if (page != pagerState.currentPage) {
+    0.dp
+} else {
+    val maxDeltaValue = 10.dp
+    val pageOffset = pagerState.currentPageOffsetFraction.absoluteValue
+    maxDeltaValue * (1f - pageOffset * 2)
+}
+
+@Preview
+@Composable
+fun WordPagerPreview() {
+    StupidEnglishTheme {
+        WordPager(
+            listOf(
+                "Баклан" to "Человек, не разбирающийся в вопросе",
+                "Ёкать" to "Издавать от неожиданности неопределенные отрывистые звуки",
+                "Ёрничать" to "Озорничать, допускать колкости по отношению к другим",
+                "Изюбрь" to "Грациозный благородный олень",
+            )
         )
     }
 }

--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
@@ -2,6 +2,9 @@ package io.taptap.stupidenglish.features.groupdetails.ui
 
 import android.content.Context
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -36,10 +39,15 @@ import androidx.compose.material.rememberDismissState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -301,19 +309,12 @@ fun WordPager(
         ) { page ->
             val pageHeightDelta = calculatePageHeightDelta(pagerState, page)
 
-            Card(
-                Modifier
+            RotatablePage(
+                word = words[page],
+                modifier = Modifier
                     .fillMaxWidth()
                     .height(pageHeight + pageHeightDelta)
-            ) {
-                Box {
-                    Text(
-                        text = words[page].first,
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                    )
-                }
-            }
+            )
         }
 
         Row(
@@ -360,6 +361,64 @@ fun WordPagerPreview() {
                 "Ёрничать" to "Озорничать, допускать колкости по отношению к другим",
                 "Изюбрь" to "Грациозный благородный олень",
             )
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun RotatablePage(
+    word: Pair<String, String>,
+    modifier: Modifier = Modifier,
+) {
+    val (text, description) = word
+    var angle by remember {
+        mutableFloatStateOf(0f)
+    }
+
+    val rotation = animateFloatAsState(
+        targetValue = angle,
+        animationSpec = tween(
+            durationMillis = 400,
+            easing = FastOutSlowInEasing,
+        ),
+        label = "Page rotation"
+    )
+
+    Card(
+        modifier = modifier
+            .graphicsLayer {
+                rotationX = rotation.value
+            },
+        onClick = {
+            angle = (angle + 180) % 360
+        }
+    ) {
+        Box(
+            modifier = Modifier.graphicsLayer {
+                //rotate content back
+                rotationX = -rotation.value
+            }
+        ) {
+            Text(
+                text = if (rotation.value > 90f) description else text,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(all = 16.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun RotatablePagePreview() {
+    StupidEnglishTheme {
+        RotatablePage(
+            word = "Баклан" to "Человек, не разбирающийся в вопросе",
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
         )
     }
 }

--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
@@ -25,10 +25,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.taptap.stupidenglish.R
 import io.taptap.stupidenglish.base.LAUNCH_LISTEN_FOR_EFFECTS
+import io.taptap.stupidenglish.base.model.Word
 import io.taptap.stupidenglish.base.model.WordWithGroups
+import io.taptap.stupidenglish.features.groupdetails.ui.GroupDetailsContract.*
 import io.taptap.stupidenglish.features.groupdetails.ui.model.GroupDetailsButtonUI
 import io.taptap.stupidenglish.features.groupdetails.ui.model.GroupDetailsDynamicTitleUI
 import io.taptap.stupidenglish.features.groupdetails.ui.model.GroupDetailsEmptyUI
@@ -43,6 +46,7 @@ import io.taptap.uikit.StupidEnglishTopAppBar
 import io.taptap.uikit.complex.WordItemRow
 import io.taptap.uikit.fab.BOTTOM_BAR_MARGIN
 import io.taptap.uikit.group.getTitle
+import io.taptap.uikit.theme.StupidEnglishTheme
 import io.taptap.uikit.theme.StupidLanguageBackgroundBox
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -54,11 +58,11 @@ import kotlinx.coroutines.flow.onEach
 @Composable
 fun GroupDetailsScreen(
     context: Context,
-    state: GroupDetailsContract.State,
+    state: State,
     mainList: List<GroupDetailsUIModel>,
-    effectFlow: Flow<GroupDetailsContract.Effect>?,
-    onEventSent: (event: GroupDetailsContract.Event) -> Unit,
-    onNavigationRequested: (navigationEffect: GroupDetailsContract.Effect.Navigation) -> Unit
+    effectFlow: Flow<Effect>?,
+    onEventSent: (event: Event) -> Unit,
+    onNavigationRequested: (navigationEffect: Effect.Navigation) -> Unit
 ) {
     val scaffoldState: ScaffoldState = rememberScaffoldState()
 
@@ -66,38 +70,34 @@ fun GroupDetailsScreen(
     LaunchedEffect(LAUNCH_LISTEN_FOR_EFFECTS) {
         effectFlow?.onEach { effect ->
             when (effect) {
-                is GroupDetailsContract.Effect.GetWordsError ->
+                is Effect.GetWordsError ->
                     scaffoldState.snackbarHostState.showSnackbar(
                         message = context.getString(effect.errorRes),
                         duration = SnackbarDuration.Short
                     )
-                is GroupDetailsContract.Effect.ShowRecover -> {
+
+                is Effect.ShowRecover -> {
                     val snackbarResult = scaffoldState.snackbarHostState.showSnackbar(
                         message = context.getString(R.string.grdt_delete_message),
                         duration = SnackbarDuration.Short,
                         actionLabel = context.getString(R.string.grdt_recover)
                     )
                     when (snackbarResult) {
-                        SnackbarResult.Dismissed -> onEventSent(GroupDetailsContract.Event.OnApplyDismiss)
-                        SnackbarResult.ActionPerformed -> onEventSent(GroupDetailsContract.Event.OnRecover)
+                        SnackbarResult.Dismissed -> onEventSent(Event.OnApplyDismiss)
+                        SnackbarResult.ActionPerformed -> onEventSent(Event.OnRecover)
                     }
                 }
-                is GroupDetailsContract.Effect.Navigation.BackTo -> onNavigationRequested(effect)
-                is GroupDetailsContract.Effect.Navigation.ToAddSentence -> onNavigationRequested(
-                    effect
-                )
-                is GroupDetailsContract.Effect.Navigation.ToAddWordWithGroup -> onNavigationRequested(
-                    effect
-                )
-                is GroupDetailsContract.Effect.Navigation.ToFlashCards -> onNavigationRequested(
-                    effect
-                )
+
+                is Effect.Navigation.BackTo -> onNavigationRequested(effect)
+                is Effect.Navigation.ToAddSentence -> onNavigationRequested(effect)
+                is Effect.Navigation.ToAddWordWithGroup -> onNavigationRequested(effect)
+                is Effect.Navigation.ToFlashCards -> onNavigationRequested(effect)
             }
         }?.collect()
     }
 
     BackHandler {
-        onEventSent(GroupDetailsContract.Event.OnBackClick)
+        onEventSent(Event.OnBackClick)
     }
 
     StupidEnglishScaffold(
@@ -114,15 +114,15 @@ fun GroupDetailsScreen(
 @OptIn(ExperimentalMaterialApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ContentScreen(
-    state: GroupDetailsContract.State,
+    state: State,
     mainList: List<GroupDetailsUIModel>,
-    onEventSent: (event: GroupDetailsContract.Event) -> Unit
+    onEventSent: (event: Event) -> Unit
 ) {
     StupidLanguageBackgroundBox(
         topbar = {
             StupidEnglishTopAppBar(
                 text = "",
-                onNavigationClick = { onEventSent(GroupDetailsContract.Event.OnBackClick) },
+                onNavigationClick = { onEventSent(Event.OnBackClick) },
             )
         }
     ) {
@@ -147,7 +147,7 @@ fun MainList(
     groupItems: List<GroupDetailsUIModel>,
     deletedWords: List<WordWithGroups>,
     listState: LazyListState,
-    onEventSent: (event: GroupDetailsContract.Event) -> Unit
+    onEventSent: (event: Event) -> Unit
 ) {
     LazyColumn(
         state = listState,
@@ -166,13 +166,13 @@ fun MainList(
                 if (dismissState.currentValue != DismissValue.Default) {
                     LaunchedEffect(Unit) {
                         dismissState.reset()
-                        onEventSent(GroupDetailsContract.Event.OnRecovered(item as GroupDetailsWordItemUI))
+                        onEventSent(Event.OnRecovered(item as GroupDetailsWordItemUI))
                     }
                 }
             } else {
                 if (item is GroupDetailsWordItemUI) {
                     if (dismissState.isDismissed(DismissDirection.StartToEnd)) {
-                        onEventSent(GroupDetailsContract.Event.OnDismiss(item))
+                        onEventSent(Event.OnDismiss(item))
                     }
                 }
             }
@@ -182,22 +182,25 @@ fun MainList(
                     text = stringResource(id = item.valueRes),
                     onClick = {
                         when (item.buttonId) {
-                            GroupDetailsContract.ButtonId.remove -> onEventSent(GroupDetailsContract.Event.OnRemoveGroupClick)
-                            GroupDetailsContract.ButtonId.flashcards -> onEventSent(GroupDetailsContract.Event.ToFlashCards)
-                            GroupDetailsContract.ButtonId.learn -> onEventSent(GroupDetailsContract.Event.ToAddSentence)
-                            GroupDetailsContract.ButtonId.addWord -> onEventSent(GroupDetailsContract.Event.OnAddWordClick)
+                            ButtonId.remove -> onEventSent(Event.OnRemoveGroupClick)
+                            ButtonId.flashcards -> onEventSent(Event.ToFlashCards)
+                            ButtonId.learn -> onEventSent(Event.ToAddSentence)
+                            ButtonId.addWord -> onEventSent(Event.OnAddWordClick)
                         }
                     }
                 )
+
                 is GroupDetailsDynamicTitleUI -> AverageTitle(
                     text = item.currentGroup.getTitle(),
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 8.dp)
                 )
+
                 is GroupDetailsEmptyUI -> EmptyListContent(
                     title = stringResource(id = R.string.word_empty_list_title),
                     description = stringResource(id = item.descriptionRes),
                     modifier = Modifier.height(300.dp)
                 )
+
                 is GroupDetailsWordItemUI -> WordItemRow(
                     word = item.word,
                     description = item.description,
@@ -207,5 +210,39 @@ fun MainList(
                 )
             }
         }
+    }
+}
+
+
+@Preview
+@ExperimentalMaterialApi
+@ExperimentalFoundationApi
+@Composable
+fun MainListPreview() {
+    StupidEnglishTheme {
+        MainList(
+            groupItems = listOf(
+                GroupDetailsDynamicTitleUI(GroupItemUI(0, "Group name")),
+                //
+                GroupDetailsButtonUI(ButtonId.addWord, R.string.grdt_add_word),
+                GroupDetailsButtonUI(ButtonId.learn, R.string.grdt_learn),
+                GroupDetailsButtonUI(ButtonId.remove, R.string.grdt_remove),
+                GroupDetailsButtonUI(ButtonId.flashcards, R.string.grdt_flashcards),
+                GroupDetailsButtonUI(ButtonId.share, R.string.grdt_share),
+                //
+                GroupDetailsWordItemUI(id = 0, word = "Word", description = "Description"),
+                GroupDetailsWordItemUI(id = 1, word = "Word", description = "Description"),
+                GroupDetailsWordItemUI(id = 2, word = "Word", description = "Description"),
+                GroupDetailsWordItemUI(id = 3, word = "Word", description = "Description"),
+            ),
+            deletedWords = listOf(
+                WordWithGroups(
+                    word = Word(4, "Deleted word", "desciption", 0),
+                    groups = listOf()
+                )
+            ),
+            listState = rememberLazyListState(),
+            onEventSent = {},
+        )
     }
 }

--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -164,6 +165,7 @@ fun ContentScreen(
             groupItems = mainList,
             deletedWords = state.deletedWords,
             listState = listState,
+            isWordPagerEnabled = true,
             onEventSent = onEventSent
         )
         if (state.isLoading) {
@@ -179,6 +181,7 @@ fun MainList(
     groupItems: List<GroupDetailsUIModel>,
     deletedWords: List<WordWithGroups>,
     listState: LazyListState,
+    isWordPagerEnabled: Boolean,
     onEventSent: (event: Event) -> Unit
 ) {
     LazyColumn(
@@ -188,6 +191,10 @@ fun MainList(
             bottom = WindowInsets.navigationBars.getBottom(LocalDensity.current).dp + 12.dp + BOTTOM_BAR_MARGIN
         )
     ) {
+        if (isWordPagerEnabled) {
+            addWordPager(groupItems)
+        }
+
         items(
             items = groupItems,
             key = { it.id }
@@ -245,6 +252,38 @@ fun MainList(
     }
 }
 
+@ExperimentalFoundationApi
+private fun LazyListScope.addWordPager(groupItems: List<GroupDetailsUIModel>) {
+    val words = groupItems.mapNotNull {
+        (it as? GroupDetailsWordItemUI)?.run {
+            word to description
+        }
+    }
+
+    if (words.isEmpty()) {
+        return
+    }
+
+    item("WordPager") {
+        val pagerState = rememberPagerState {
+            words.size
+        }
+        Column {
+            WordPager(
+                words = words,
+                pagerState = pagerState
+            )
+            if (words.size > 1) {
+                PagerIndicator(
+                    totalDots = pagerState.pageCount,
+                    selectedIndex = pagerState.currentPage,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                )
+            }
+        }
+    }
+}
 
 @Preview
 @ExperimentalMaterialApi
@@ -274,6 +313,7 @@ fun MainListPreview() {
                 )
             ),
             listState = rememberLazyListState(),
+            isWordPagerEnabled = true,
             onEventSent = {},
         )
     }

--- a/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsViewModel.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/groupdetails/ui/GroupDetailsViewModel.kt
@@ -125,6 +125,8 @@ class GroupDetailsViewModel @Inject constructor(
     ): List<GroupDetailsUIModel> {
         val mainList = mutableListOf<GroupDetailsUIModel>()
 
+        mainList.add(GroupDetailsDynamicTitleUI(currentGroup = group))
+
         mainList.add(
             GroupDetailsButtonUI(
                 valueRes = R.string.grdt_add_word,
@@ -156,7 +158,6 @@ class GroupDetailsViewModel @Inject constructor(
             )
         )
 
-        mainList.add(GroupDetailsDynamicTitleUI(currentGroup = group))
         if (words.isEmpty()) {
             mainList.add(GroupDetailsEmptyUI(descriptionRes = R.string.word_empty_list_description))
         } else {

--- a/app/src/main/java/io/taptap/stupidenglish/features/words/ui/WordListScreen.kt
+++ b/app/src/main/java/io/taptap/stupidenglish/features/words/ui/WordListScreen.kt
@@ -351,7 +351,9 @@ private fun MainList(
                 is WordListItemUI -> WordItemRow(
                     word = item.word,
                     description = item.description,
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier
+                        .animateItemPlacement()
+                        .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp),
                     dismissState = dismissState,
                     onClicked = {
                         onEventSent(WordListContract.Event.OnWordClick)

--- a/core/uikit/src/main/java/io/taptap/uikit/complex/WordItem.kt
+++ b/core/uikit/src/main/java/io/taptap/uikit/complex/WordItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.SwipeToDismiss
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.rememberDismissState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,8 +29,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.taptap.uikit.AverageTitle
+import io.taptap.uikit.theme.StupidEnglishTheme
 
 @ExperimentalMaterialApi
 @Composable
@@ -45,8 +48,7 @@ fun WordItemRow(
         dismissThresholds = { direction ->
             FractionalThreshold(0.5f)
         },
-        modifier = modifier
-            .padding(vertical = 1.dp),
+        modifier = modifier,
         directions = setOf(DismissDirection.StartToEnd),
         background = {
             val scale by animateFloatAsState(
@@ -75,7 +77,6 @@ fun WordItemRow(
             ).value,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
                 .clickable {
                     onClicked()
                 }
@@ -94,6 +95,21 @@ fun WordItemRow(
                     .align(Alignment.CenterVertically)
             )
         }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Preview
+@Composable
+fun WordItemRowPreview() {
+    StupidEnglishTheme {
+        WordItemRow(
+            word = "Word",
+            description = "Description",
+            onClicked = { },
+            dismissState = rememberDismissState(),
+            modifier = Modifier
+        )
     }
 }
 


### PR DESCRIPTION
![2023-06-21 20 31 05](https://github.com/taptappub/StupidEnglish/assets/2972853/f8e7f57d-27f2-4384-99d6-fbb323f12031)


Что сделано:
- Добавил ViewPager в качестве захардкоженного первого элемента списка
- Настроил отступы для элементов списка
- Перенёс название группы выше кнопок

На что обратить внимание:
- Я не смог разобраться и понять почему в превью не работают анимации
- По новому коду есть magic numbers. Нужно бы их обсудить и понять подробнее
- Мне не нравится анимация точек индикатора. Хочется чтобы точки начинали двигаться когда пользователь начинает сдвигать карточку
- Тулбар некрасиво обрезает контент ViewPager

Вопросы на тему:
- Чем конкретно отличается LazyRow от ViewPager?
- Зачем мы формируем список `List<GroupDetailsUIModel>` и потом разруливаем его в `when`? Кажется, что у нас есть достаточно жёсткая структура списка: ViewPager, один заголовок с названием группы, несколько кнопок, несколько слов. Надо подумать — может быть можно упростить работу с кодом избавившись от необязательных моделей или структур
